### PR TITLE
Make it build with ghc-9.12

### DIFF
--- a/tasty-inspection-testing.cabal
+++ b/tasty-inspection-testing.cabal
@@ -27,11 +27,11 @@ library
   exposed-modules:  Test.Tasty.Inspection
                     Test.Tasty.Inspection.Plugin
   other-modules:    Test.Tasty.Inspection.Internal
-  build-depends:    base < 4.21,
-                    ghc < 9.11,
+  build-depends:    base < 4.22,
+                    ghc < 9.13,
                     inspection-testing >= 0.5 && < 0.6,
                     tasty < 1.6,
-                    template-haskell < 2.23
+                    template-haskell < 2.24
   hs-source-dirs:   src
   default-language: Haskell2010
   ghc-options:      -Wall -Wcompat


### PR DESCRIPTION
The first alpha of `ghc-9.12` has just been released.

This can be fixed with a Hackage metadata edit, and I (as a Hackage Trustee) am able to do this for you if you would like.