### PR TITLE
Allow inspection-testing 0.6

### DIFF
--- a/tasty-inspection-testing.cabal
+++ b/tasty-inspection-testing.cabal
@@ -29,7 +29,7 @@ library
   other-modules:    Test.Tasty.Inspection.Internal
   build-depends:    base < 4.22,
                     ghc < 9.13,
-                    inspection-testing >= 0.5 && < 0.6,
+                    inspection-testing >= 0.5 && < 0.7,
                     tasty < 1.6,
                     template-haskell < 2.24
   hs-source-dirs:   src


### PR DESCRIPTION
The (possible) breaking change at https://github.com/nomeata/inspection-testing/pull/81 shouldn't affect us.